### PR TITLE
fix: mobile image scaling

### DIFF
--- a/layouts/shortcodes/blocks/blog-image.html
+++ b/layouts/shortcodes/blocks/blog-image.html
@@ -1,5 +1,5 @@
 {{/* layouts/shortcodes/blocks/blog-image.html */}}
-<div class="card mb-3" style="width: 40rem;">
+<div class="card mb-3" style="max-width: 90vw; width: 40rem">
     <img src="{{ .Get "src" | absURL }}" class="card-img-top" alt="{{ .Get "alt" }}">
     <div class="card-body">
       <p class="card-text">{{ .Get "text" }}</p>


### PR DESCRIPTION
Just added a "max-width: 90vw;" rule to the image cards for the blog so that they will scale well on smaller screens.