### PR TITLE
Fix hugo change detection for rosenpass.css

### DIFF
--- a/static/css/rosenpass.css
+++ b/static/css/rosenpass.css
@@ -2550,5 +2550,3 @@ iframe.portrait {
 }
     
 .download-button a {  color: var(--bs-white) !important; }
-
-}


### PR DESCRIPTION
An extra bracket was introduced in 48c0f019213014341c3d68f52ff3dc71a7446485. Apparently, this syntax error prevents hugo from updating the static site on CSS changes - or at least it did for me, when running `nix develop`. (Oddly, neither `serve` nor `build` raised any errors)