### PR TITLE
Fix scroll bar positioning for code blocks

### DIFF
--- a/static/css/rosenpass.css
+++ b/static/css/rosenpass.css
@@ -507,8 +507,7 @@ div.click-to-copy{
 }
 
 .highlight:has(pre):has(div):has(code) code{
-  text-overflow: auto;
-  max-width: 100%;
+  width: 100%;
   overflow: auto;
 }
 


### PR DESCRIPTION
Setting `max-width` here looks like a mistake. As a result, the scroll bar is rendered inside the code block.

(And `auto` isn't a valid `text-overflow` property value, so it can safely be removed)

---

Example:

![image](https://github.com/user-attachments/assets/9948ecd0-06cb-41a0-b57b-a17e8fa992bc)

(YMMV depending on browser and screen resolution - it looks somewhat different on Chrome for me, but still broken)