### PR TITLE
flake.nix: fix devShell dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
             groff
             hugo
             nodejs
+            go
             nodePackages.prettier
           ];
           git.hooks = {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
           src = ./.;  # This should point to your source folder
           packageJson = ./package.json;
           packageLockJson = ./package-lock.json;
-          nodejs = pkgs.nodejs_20;  # Explicitly use Node.js 20
+          nodejs = pkgs.nodejs;
         };
 
         packages.website = pkgs.stdenvNoCC.mkDerivation {
@@ -55,7 +55,7 @@
           packages = with pkgs; [
             groff
             hugo
-            nodejs_20
+            nodejs
             nodePackages.prettier
           ];
           git.hooks = {


### PR DESCRIPTION
`go` was missing in the `devShell` and `nodejs` was pinned to a deprecated version.

- closes #226 
- closes #222 

There is a plethora of other PRs in this context, e.g. #220. 